### PR TITLE
Chore: Cleanup Koin modules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,5 +107,4 @@ dependencies {
   testImplementation(libs.junit.jupiter)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.koin.test)
-  testImplementation(libs.mockito.core)
 }

--- a/app/src/main/kotlin/com/routesearch/di/AppModule.kt
+++ b/app/src/main/kotlin/com/routesearch/di/AppModule.kt
@@ -3,5 +3,13 @@ package com.routesearch.di
 import com.routesearch.data.dataModule
 import com.routesearch.navigation.navigationModule
 import com.routesearch.ui.common.commonUiModule
+import org.koin.dsl.module
 
-internal val appModule = dataModule + commonUiModule + navigationModule
+internal val appModule = module {
+
+  includes(
+    dataModule,
+    commonUiModule,
+    navigationModule,
+  )
+}

--- a/app/src/test/kotlin/com/routesearch/di/AppModuleTest.kt
+++ b/app/src/test/kotlin/com/routesearch/di/AppModuleTest.kt
@@ -1,18 +1,12 @@
 package com.routesearch.di
 
-import android.app.Application
 import org.junit.jupiter.api.Test
-import org.koin.android.ext.koin.androidContext
-import org.koin.dsl.koinApplication
-import org.koin.test.KoinTest
-import org.koin.test.check.checkModules
-import org.mockito.Mockito.mock
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.test.verify.verify
 
-class AppModuleTest : KoinTest {
+class AppModuleTest {
 
+  @OptIn(KoinExperimentalAPI::class)
   @Test
-  fun checkKoinModule() = koinApplication {
-    androidContext(mock(Application::class.java))
-    modules(appModule)
-  }.checkModules()
+  fun checkKoinModule() = appModule.verify()
 }

--- a/data/local/src/main/kotlin/com/routesearch/data/local/LocalDataModule.kt
+++ b/data/local/src/main/kotlin/com/routesearch/data/local/LocalDataModule.kt
@@ -11,17 +11,17 @@ import org.koin.dsl.module
 
 val localDataModule = module {
 
+  single<String>(DatabaseName) { "route_search_database" }
+
   single<RouteSearchDataBase> {
     Room.databaseBuilder(
       context = androidContext(),
       klass = RouteSearchDataBase::class.java,
-      name = "route_search_database",
+      name = get<String>(DatabaseName),
     ).build()
   }
 
-  single<AreaDao> {
-    get<RouteSearchDataBase>().areaDao
-  }
+  single<AreaDao> { get<RouteSearchDataBase>().areaDao }
 
   singleOf(::AreaRoomDataSource) bind AreaLocalDataSource::class
 }

--- a/data/local/src/main/kotlin/com/routesearch/data/local/Qualifiers.kt
+++ b/data/local/src/main/kotlin/com/routesearch/data/local/Qualifiers.kt
@@ -1,0 +1,5 @@
+package com.routesearch.data.local
+
+import org.koin.core.qualifier.StringQualifier
+
+val DatabaseName = StringQualifier("database-name")

--- a/data/remote/src/main/kotlin/com/routesearch/data/remote/Qualifiers.kt
+++ b/data/remote/src/main/kotlin/com/routesearch/data/remote/Qualifiers.kt
@@ -1,0 +1,11 @@
+package com.routesearch.data.remote
+
+import org.koin.core.qualifier.StringQualifier
+
+internal val TypeSenseTimeout = StringQualifier("type-sense-duration")
+internal val TypeSenseProtocol = StringQualifier("type-sense-protocol")
+internal val TypeSensePort = StringQualifier("type-sense-port")
+internal val TypeSenseNodes = StringQualifier("type-sense-nodes")
+internal val TypeSenseApiKey = StringQualifier("type-sense-api-key")
+internal val TypeSenseApiUrl = StringQualifier("type-sense-api-url")
+internal val TypeSenseHost = StringQualifier("type-sense-host")

--- a/data/src/main/kotlin/com/routesearch/data/DataModule.kt
+++ b/data/src/main/kotlin/com/routesearch/data/DataModule.kt
@@ -8,7 +8,12 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-val dataModule = remoteDataModule + localDataModule + module {
+val dataModule = module {
+
+  includes(
+    remoteDataModule,
+    localDataModule,
+  )
 
   singleOf(::DefaultAreaRepository) bind AreaRepository::class
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ ktlint = "11.5.1"
 leakcanary = "2.12"
 lifecycle = "2.6.1"
 logcat = "0.1"
-mockito = "5.5.0"
 moshi = "1.14.0"
 navigation = "2.7.3"
 room = "2.6.0"
@@ -52,7 +51,6 @@ leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-and
 lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "lifecycle" }
 logcat = { group = "com.squareup.logcat", name = "logcat", version.ref = "logcat" }
 material3 = { group = "androidx.compose.material3", name = "material3" }
-mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 moshi = { group = "com.squareup.moshi", name = "moshi", version.ref = "moshi" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
 navigation-common = { group = "androidx.navigation", name = "navigation-common", version.ref = "navigation" }


### PR DESCRIPTION
This pr does some minor Koin cleanup. This lets us remove Mockito as a dependency and will let us write Koin tests easier in the future.