### PR TITLE
Feat: Search Screen

### DIFF
--- a/app/src/main/kotlin/com/routesearch/navigation/MainNavGraph.kt
+++ b/app/src/main/kotlin/com/routesearch/navigation/MainNavGraph.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import com.routesearch.features.area.AreaScreen
+import com.routesearch.features.search.SearchScreen
 import com.routesearch.ui.common.util.screen
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -30,9 +31,10 @@ fun MainNavGraph(
   }
   NavHost(
     navController = navController,
-    startDestination = AreaScreen.route,
+    startDestination = SearchScreen.route,
     modifier = modifier,
   ) {
+    screen(SearchScreen)
     screen(AreaScreen)
   }
 }

--- a/data/remote/src/main/kotlin/com/routesearch/data/remote/RemoteDataModule.kt
+++ b/data/remote/src/main/kotlin/com/routesearch/data/remote/RemoteDataModule.kt
@@ -22,7 +22,7 @@ val remoteDataModule = module {
 
   single<String>(TypeSensePort) { "443" }
 
-  single<String>(TypeSenseProtocol) { "http" }
+  single<String>(TypeSenseProtocol) { "https" }
 
   single<String>(TypeSenseApiKey) { BuildConfig.TYPE_SENSE_API_KEY }
 

--- a/data/remote/src/main/kotlin/com/routesearch/data/remote/RemoteDataModule.kt
+++ b/data/remote/src/main/kotlin/com/routesearch/data/remote/RemoteDataModule.kt
@@ -66,4 +66,6 @@ val remoteDataModule = module {
   }
 
   singleOf(::AreaApolloDataSource) bind AreaRemoteDataSource::class
+
+  singleOf(::AreaSearchTypeSenseDataSource) bind AreaSearchDataSource::class
 }

--- a/data/remote/src/main/kotlin/com/routesearch/data/remote/area/search/AreaSearchTypeSenseDataSource.kt
+++ b/data/remote/src/main/kotlin/com/routesearch/data/remote/area/search/AreaSearchTypeSenseDataSource.kt
@@ -26,7 +26,7 @@ internal class AreaSearchTypeSenseDataSource(
       .hits
       .mapNotNull {
         moshi.adapter<AreaSearchResult>()
-          .fromJsonValue(it)
+          .fromJsonValue(it.document)
       }.let { Result.success(it) }
   } catch (e: TypesenseError) {
     Result.failure(e)

--- a/data/src/main/kotlin/com/routesearch/data/DataModule.kt
+++ b/data/src/main/kotlin/com/routesearch/data/DataModule.kt
@@ -2,9 +2,12 @@ package com.routesearch.data
 
 import com.routesearch.data.area.AreaRepository
 import com.routesearch.data.area.DefaultAreaRepository
+import com.routesearch.data.area.search.AreaSearchService
+import com.routesearch.data.area.search.DefaultAreaSearchService
 import com.routesearch.data.local.area.AreaLocalDataSource
 import com.routesearch.data.local.localDataModule
 import com.routesearch.data.remote.area.AreaRemoteDataSource
+import com.routesearch.data.remote.area.search.AreaSearchDataSource
 import com.routesearch.data.remote.remoteDataModule
 import com.routesearch.util.coroutines.IoContext
 import org.koin.dsl.bind
@@ -25,4 +28,11 @@ val dataModule = module {
       coroutineContext = get<CoroutineContext>(IoContext),
     )
   } bind AreaRepository::class
+
+  single {
+    DefaultAreaSearchService(
+      areasSearchDataSource = get<AreaSearchDataSource>(),
+      coroutineContext = get<CoroutineContext>(IoContext),
+    )
+  } bind AreaSearchService::class
 }

--- a/data/src/main/kotlin/com/routesearch/data/area/search/DefaultAreaSearchService.kt
+++ b/data/src/main/kotlin/com/routesearch/data/area/search/DefaultAreaSearchService.kt
@@ -1,11 +1,16 @@
 package com.routesearch.data.area.search
 
 import com.routesearch.data.remote.area.search.AreaSearchDataSource
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 internal class DefaultAreaSearchService(
   private val areasSearchDataSource: AreaSearchDataSource,
+  private val coroutineContext: CoroutineContext,
 ) : AreaSearchService {
 
-  override suspend fun searchForAreas(query: String) = areasSearchDataSource.searchForAreas(query)
-    .map { it.toAreaSearchResults() }
+  override suspend fun searchForAreas(query: String) = withContext(coroutineContext) {
+    areasSearchDataSource.searchForAreas(query)
+      .map { it.toAreaSearchResults() }
+  }
 }

--- a/features/build.gradle.kts
+++ b/features/build.gradle.kts
@@ -24,6 +24,8 @@ dependencies {
   implementation(platform(libs.compose.bom))
   implementation(platform(libs.koin.bom))
 
+  implementation(project(":navigation"))
+
   implementation(libs.constraintlayout.compose)
   implementation(libs.foundation.android)
   implementation(libs.koin.android)

--- a/features/src/main/kotlin/com/routesearch/features/FeaturesModule.kt
+++ b/features/src/main/kotlin/com/routesearch/features/FeaturesModule.kt
@@ -1,5 +1,13 @@
 package com.routesearch.features
 
 import com.routesearch.features.area.areaModule
+import com.routesearch.features.search.searchModule
+import org.koin.dsl.module
 
-val featuresModule = areaModule
+val featuresModule = module {
+
+  includes(
+    areaModule,
+    searchModule,
+  )
+}

--- a/features/src/main/kotlin/com/routesearch/features/area/AreaScreen.kt
+++ b/features/src/main/kotlin/com/routesearch/features/area/AreaScreen.kt
@@ -57,6 +57,8 @@ object AreaScreen : Screen {
 
   override val arguments = listOf(areaIdArg)
 
+  fun getDestination(areaId: String) = "area?areaId=$areaId"
+
   @Composable
   override fun Content() {
     val viewModel = koinViewModel<AreaViewModel>()

--- a/features/src/main/kotlin/com/routesearch/features/area/AreaScreen.kt
+++ b/features/src/main/kotlin/com/routesearch/features/area/AreaScreen.kt
@@ -50,7 +50,6 @@ object AreaScreen : Screen {
   internal val areaIdArg = navArgument("areaId") {
     nullable = false
     type = NavType.StringType
-    defaultValue = "acd5e4e7-2972-5435-a237-4cea3dffe6cb"
   }
 
   override val route = "area?${areaIdArg.name}={${areaIdArg.name}}"

--- a/features/src/main/kotlin/com/routesearch/features/search/SearchModule.kt
+++ b/features/src/main/kotlin/com/routesearch/features/search/SearchModule.kt
@@ -1,0 +1,9 @@
+package com.routesearch.features.search
+
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.dsl.module
+
+internal val searchModule = module {
+
+  viewModelOf(::SearchViewModel)
+}

--- a/features/src/main/kotlin/com/routesearch/features/search/SearchScreen.kt
+++ b/features/src/main/kotlin/com/routesearch/features/search/SearchScreen.kt
@@ -1,0 +1,166 @@
+package com.routesearch.features.search
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.routesearch.data.area.search.AreaSearchResult
+import com.routesearch.features.R
+import com.routesearch.ui.common.Screen
+import com.routesearch.ui.common.theme.RouteSearchTheme
+import org.koin.androidx.compose.koinViewModel
+
+object SearchScreen : Screen {
+
+  override val route = "search"
+
+  @Composable
+  override fun Content() {
+    val viewModel = koinViewModel<SearchViewModel>()
+    val viewState by viewModel.viewState.collectAsStateWithLifecycle()
+
+    SearchScreenContent(
+      viewState = viewState,
+      onSearch = viewModel::onSearch,
+      onSearchQueryChange = viewModel::onSearchQueryChange,
+      onResultClick = viewModel::onAreaClicked,
+    )
+  }
+}
+
+@Composable
+private fun SearchScreenContent(
+  viewState: SearchViewState,
+  onSearchQueryChange: (String) -> Unit,
+  onSearch: (String) -> Unit,
+  onResultClick: (String) -> Unit,
+) = ConstraintLayout(
+  modifier = Modifier
+    .fillMaxSize(),
+) {
+  val (
+    searchBar,
+  ) = createRefs()
+
+  SearchBar(
+    modifier = Modifier
+      .wrapContentHeight()
+      .constrainAs(searchBar) {
+        start.linkTo(parent.start)
+        end.linkTo(parent.end)
+        top.linkTo(parent.top)
+      },
+    onSearchQueryChanged = onSearchQueryChange,
+    onSearch = onSearch,
+  ) {
+    SearchResultsList(
+      modifier = Modifier.fillMaxSize(),
+      searchResults = viewState.areaSearchResults,
+      onResultClicked = onResultClick,
+    )
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SearchBar(
+  modifier: Modifier,
+  onSearchQueryChanged: (String) -> Unit,
+  onSearch: (String) -> Unit,
+  content: @Composable ColumnScope.() -> Unit,
+) {
+  var query by rememberSaveable { mutableStateOf("") }
+  var active by rememberSaveable { mutableStateOf(false) }
+
+  SearchBar(
+    modifier = modifier,
+    query = query,
+    onQueryChange = {
+      onSearchQueryChanged(it)
+      query = it
+    },
+    onSearch = onSearch,
+    active = active,
+    onActiveChange = { active = it },
+    placeholder = { Text(stringResource(R.string.search_screen_search_placeholder)) },
+    leadingIcon = {
+      if (active) {
+        Icon(
+          modifier = Modifier.clickable { active = false },
+          imageVector = Icons.Default.ArrowBack,
+          contentDescription = null,
+        )
+      } else {
+        Icon(
+          imageVector = Icons.Default.Search,
+          contentDescription = null,
+        )
+      }
+    },
+    content = content,
+  )
+}
+
+@Composable
+private fun SearchResultsList(
+  modifier: Modifier,
+  searchResults: List<AreaSearchResult>,
+  onResultClicked: (String) -> Unit,
+) = LazyColumn(
+  modifier = modifier,
+) {
+  items(searchResults) {
+    AreaSearchResult(
+      result = it,
+      onResultClicked = onResultClicked,
+    )
+  }
+}
+
+@Composable
+private fun AreaSearchResult(
+  result: AreaSearchResult,
+  onResultClicked: (String) -> Unit,
+) = ListItem(
+  modifier = Modifier.clickable { onResultClicked(result.id) },
+  headlineContent = { Text(result.name) },
+  supportingContent = { Text(result.pathTokens.joinToString(" / ")) },
+)
+
+@Preview
+@Composable
+fun SearchScreenPreview() = RouteSearchTheme {
+  Surface(
+    modifier = Modifier.fillMaxSize(),
+    color = MaterialTheme.colorScheme.background,
+  ) {
+    SearchScreenContent(
+      viewState = SearchViewState(),
+      onSearch = { },
+      onResultClick = { },
+      onSearchQueryChange = { },
+    )
+  }
+}

--- a/features/src/main/kotlin/com/routesearch/features/search/SearchViewModel.kt
+++ b/features/src/main/kotlin/com/routesearch/features/search/SearchViewModel.kt
@@ -1,0 +1,82 @@
+package com.routesearch.features.search
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.routesearch.data.area.search.AreaSearchResult
+import com.routesearch.data.area.search.AreaSearchService
+import com.routesearch.features.R
+import com.routesearch.features.area.AreaScreen
+import com.routesearch.navigation.Navigator
+import com.routesearch.ui.common.snackbar.SnackbarManager
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+private const val SEARCH_DEBOUNCE_MS = 200L
+
+@OptIn(FlowPreview::class)
+internal class SearchViewModel(
+  private val areaSearchService: AreaSearchService,
+  private val snackbarManager: SnackbarManager,
+  private val navigator: Navigator,
+) : ViewModel() {
+
+  private val _viewState = MutableStateFlow(SearchViewState())
+  val viewState = _viewState.asStateFlow()
+
+  private var searchQuery = MutableStateFlow("")
+  private var searchJob: Job? = null
+
+  init {
+    viewModelScope.launch {
+      searchQuery.debounce(SEARCH_DEBOUNCE_MS)
+        .filter { it.isNotBlank() }
+        .collect { search(it) }
+    }
+  }
+
+  fun onSearchQueryChange(query: String) {
+    if (query.isBlank()) {
+      cancelOngoingSearch()
+      clearSearchResults()
+    }
+
+    searchQuery.value = query
+  }
+
+  fun onSearch(query: String) = search(query)
+
+  private fun search(query: String) {
+    cancelOngoingSearch()
+    searchJob = viewModelScope.launch {
+      areaSearchService.searchForAreas(query)
+        .onSuccess(::onSearchSuccess)
+        .onFailure { onSearchFailure() }
+    }
+  }
+
+  private fun cancelOngoingSearch() = searchJob?.cancel()
+
+  private fun clearSearchResults() = _viewState.update {
+    it.copy(areaSearchResults = emptyList())
+  }
+
+  private fun onSearchSuccess(areaSearchResults: List<AreaSearchResult>) = _viewState.update {
+    it.copy(
+      areaSearchResults = areaSearchResults,
+    )
+  }
+
+  private fun onSearchFailure() {
+    snackbarManager.showSnackbar(R.string.search_screen_search_error_message)
+  }
+
+  fun onAreaClicked(id: String) {
+    navigator.navigate(AreaScreen.getDestination(id))
+  }
+}

--- a/features/src/main/kotlin/com/routesearch/features/search/SearchViewState.kt
+++ b/features/src/main/kotlin/com/routesearch/features/search/SearchViewState.kt
@@ -1,0 +1,7 @@
+package com.routesearch.features.search
+
+import com.routesearch.data.area.search.AreaSearchResult
+
+internal data class SearchViewState(
+  val areaSearchResults: List<AreaSearchResult> = emptyList(),
+)

--- a/features/src/main/res/values/strings.xml
+++ b/features/src/main/res/values/strings.xml
@@ -12,4 +12,7 @@
   </plurals>  <string name="area_screen_share_button">Share</string>
   <string name="area_screen_download_button">Download</string>
   <string name="area_screen_loading_error_message">Error Loading Area</string>
+
+  <string name="search_screen_search_error_message">Something went wrong</string>
+  <string name="search_screen_search_placeholder">Search for areas or climbs</string>
 </resources>


### PR DESCRIPTION
This pr sets up a basic search screen that allows you to search for areas and makes this the start destination of the app. Currently it does not support searching for climbs and lacks things like proper error handling, but this is more of an MVP.