### PR TITLE
Feat: Add a placeholder for empty areas

### DIFF
--- a/features/src/main/kotlin/com/routesearch/features/area/AreaPreviewParameterProvider.kt
+++ b/features/src/main/kotlin/com/routesearch/features/area/AreaPreviewParameterProvider.kt
@@ -175,6 +175,33 @@ internal val fakeAreas = listOf(
     organizations = persistentListOf(),
     media = persistentListOf(),
   ),
+  Area(
+    id = "3",
+    metadata = metadata,
+    name = "Lower Devil's Canyon",
+    description = "",
+    path = persistentListOf(
+      "USA",
+      "Arizona",
+      "Central Arizona",
+      "Queen Creek Canyon",
+      "Lower Devil's Canyon",
+    ),
+    ancestorIds = persistentListOf(),
+    gradeMap = persistentMapOf(),
+    location = location,
+    climbCount = Area.ClimbCount(
+      total = 0,
+      sport = 0,
+      trad = 0,
+      tr = 0,
+      bouldering = 0,
+    ),
+    climbs = persistentListOf(),
+    children = persistentListOf(),
+    organizations = persistentListOf(),
+    media = persistentListOf(),
+  ),
 )
 
 // Unfortunately we can't actually use PreviewParameterProvider yet because of a bug in Android Studio

--- a/features/src/main/kotlin/com/routesearch/features/area/AreaScreen.kt
+++ b/features/src/main/kotlin/com/routesearch/features/area/AreaScreen.kt
@@ -387,7 +387,6 @@ private fun Content(
         )
 
         width = Dimension.fillToConstraints
-        visibility = if (area.children.isEmpty() && area.climbs.isEmpty()) Visibility.Gone else Visibility.Visible
       }
       .padding(top = 16.dp),
     area = area,
@@ -645,19 +644,21 @@ private fun ListContent(
   onFilterClimbsClick: () -> Unit,
   onClimbClick: (String) -> Unit,
   onAreaClick: (String) -> Unit,
-) = if (area.children.isEmpty()) {
+) = if (area.children.isEmpty() && area.climbs.isNotEmpty()) {
   ClimbList(
     modifier = modifier,
     area = area,
     onFilterClick = { onFilterClimbsClick() },
     onClimbClick = { onClimbClick(it) },
   )
-} else {
+} else if (area.climbs.isEmpty() && area.children.isNotEmpty()) {
   AreaList(
     modifier = modifier,
     area = area,
     onAreaClick = { onAreaClick(it) },
   )
+} else {
+  EmptyAreaPlaceholder(modifier = modifier)
 }
 
 @Composable
@@ -818,6 +819,27 @@ private fun ClimbListItemSubtitle(climb: Area.Climb) {
   Text("$type • $pitches")
 }
 
+@Composable
+private fun EmptyAreaPlaceholder(
+  modifier: Modifier = Modifier,
+) = Column(
+  modifier = modifier,
+) {
+  Text(
+    modifier = Modifier.padding(
+      horizontal = 16.dp,
+    ),
+    text = stringResource(R.string.area_screen_empty_area_header),
+    style = MaterialTheme.typography.titleLarge,
+  )
+  Text(
+    modifier = Modifier.padding(
+      horizontal = 16.dp,
+    ),
+    text = stringResource(id = R.string.area_screen_empty_area_placeholder),
+  )
+}
+
 @PreviewLightDark
 @Composable
 private fun AreaWithChildrenPreview() = RouteSearchTheme {
@@ -844,6 +866,26 @@ private fun AreaWithClimbsPreview() = RouteSearchTheme {
   Surface {
     Content(
       area = fakeAreas[1],
+      onPathSectionClick = { },
+      onLocationClick = { },
+      onBookmarkClick = { },
+      onDownloadClick = { },
+      onShareClick = { },
+      onOrganizationClick = { },
+      onFilterClimbsClick = { },
+      onClimbClick = { },
+      onAreaClick = { },
+      onShowAllImagesClick = { },
+    )
+  }
+}
+
+@PreviewLightDark
+@Composable
+private fun EmptyAreaPreview() = RouteSearchTheme {
+  Surface {
+    Content(
+      area = fakeAreas[2],
       onPathSectionClick = { },
       onLocationClick = { },
       onBookmarkClick = { },

--- a/features/src/main/res/values/strings.xml
+++ b/features/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
   <string name="area_screen_description_header">Description</string>
   <string name="area_screen_description_placeholder">No description available. Consider contributing to this area at openbeta.io!</string>
+  <string name="area_screen_empty_area_placeholder">Looks like this area is empty. Consider contributing to this area at openbeta.io!</string>
+  <string name="area_screen_empty_area_header">0 Areas and 0 Climbs</string>
   <string name="area_screen_expand_description_button_label">See More</string>
   <string name="area_screen_loading_error_message">Error Loading Area</string>
   <plurals name="area_screen_number_of_climbs">


### PR DESCRIPTION
Added a placeholder for the area screen when there are no child areas or climbs